### PR TITLE
Fix Job names

### DIFF
--- a/src/main/java/tech/andrey/jenkins/missioncontrol/MissionControlView.java
+++ b/src/main/java/tech/andrey/jenkins/missioncontrol/MissionControlView.java
@@ -346,7 +346,12 @@ public class MissionControlView extends View {
                     status = res == null ? "UNKNOWN" : res.toString();
                 }
             }
-            String fullName = java.net.URLDecoder.decode(j.getFullName(), "UTF-8")
+
+            // Decode pipeline branch names
+            String fullName = j.getFullName();
+            try {fullName = java.net.URLDecoder.decode(j.getFullName(), "UTF-8");}
+            catch (java.io.UnsupportedEncodingException e) {e.printStackTrace();}
+
             statuses.add(new JobStatus(fullName, status));
         }
 

--- a/src/main/java/tech/andrey/jenkins/missioncontrol/MissionControlView.java
+++ b/src/main/java/tech/andrey/jenkins/missioncontrol/MissionControlView.java
@@ -346,8 +346,8 @@ public class MissionControlView extends View {
                     status = res == null ? "UNKNOWN" : res.toString();
                 }
             }
-
-            statuses.add(new JobStatus(j.getFullName(), status));
+            String fullName = java.net.URLDecoder.decode(j.getFullName(), "UTF-8")
+            statuses.add(new JobStatus(fullName, status));
         }
 
         return statuses;


### PR DESCRIPTION
Fixes `feature%2Fhello` job name to appear as `feature/hello`

just tested this on latest builds the problem still existed