### PR TITLE
Change filter to look in full job name instead of the base name.

### DIFF
--- a/src/main/java/tech/andrey/jenkins/missioncontrol/MissionControlView.java
+++ b/src/main/java/tech/andrey/jenkins/missioncontrol/MissionControlView.java
@@ -271,7 +271,7 @@ public class MissionControlView extends View {
                 continue;
 
             // If filtering is enabled, skip jobs not matching the filter
-            if (r != null && !r.matcher(job.getName()).find())
+            if (r != null && !r.matcher(job.getFullName()).find())
                 continue;
 
             Result result = build.getResult();


### PR DESCRIPTION
This would allow an entire folder of jobs to be filtered out of or into the mission control view.