### PR TITLE
Fix for Jenkins NOT_BUILT job status

### DIFF
--- a/src/main/java/tech/andrey/jenkins/missioncontrol/MissionControlView.java
+++ b/src/main/java/tech/andrey/jenkins/missioncontrol/MissionControlView.java
@@ -386,7 +386,7 @@ public class MissionControlView extends View {
             } else {
                 Run lb = j.getLastBuild();
                 if (lb == null) {
-                    status = "NOTBUILT";
+                    status = "NOT_BUILT";
                 } else {
                     Result res = lb.getResult();
                     status = res == null ? "UNKNOWN" : res.toString();
@@ -427,7 +427,7 @@ public class MissionControlView extends View {
             statuses.put("UNSTABLE", 3);
             statuses.put("ABORTED", 4);
             statuses.put("SUCCESS", 5);
-            statuses.put("NOTBUILT", 6);
+            statuses.put("NOT_BUILT", 6);
             statuses.put("DISABLED", 7);
         }
 

--- a/src/main/webapp/js/mission-control.js
+++ b/src/main/webapp/js/mission-control.js
@@ -121,7 +121,7 @@ function reload_jenkins_job_statuses(divSelector, viewUrl, buttonClass) {
           classes = 'btn-warning';
           break;
         case 'DISABLED':
-        case 'NOTBUILT':
+        case 'NOT_BUILT':
           classes = 'invert-text-color';
           break;
         case 'BUILDING':


### PR DESCRIPTION
When there is a jobs in NOT_BUILD status, the plugin fails with NPE
at the following line https://github.com/jenkinsci/mission-control-view-plugin/blob/master/src/main/java/tech/andrey/jenkins/missioncontrol/MissionControlView.java#L447

https://javadoc.jenkins-ci.org/hudson/model/Result.html#NOT_BUILT