### PR TITLE
Use displayName for job status (JENKINS-65810)

### DIFF
--- a/src/main/java/tech/andrey/jenkins/missioncontrol/MissionControlView.java
+++ b/src/main/java/tech/andrey/jenkins/missioncontrol/MissionControlView.java
@@ -393,7 +393,7 @@ public class MissionControlView extends View {
                 }
             }
 
-            statuses.add(new JobStatus(fullName, status, jobUrl));
+            statuses.add(new JobStatus(j.getFullDisplayName(), status, jobUrl));
         }
 
         if (filterByFailures) {


### PR DESCRIPTION
Don't use the plain job name, but the displayName for the job status part on the right hand side of the mission control view. The left hand side (build history) already uses the displayName, therefore this change unifies what is shown on left and right sides.

The regex filtering on job names was not changed (filtering happens on the job name, not on the job display name).

https://issues.jenkins.io/browse/JENKINS-65810

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
